### PR TITLE
Update version in package lock on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: 'NPM install'
         run: npm install
-        
+
       - name: 'Composer install'
         run: 'composer install --no-dev --prefer-dist --no-progress --no-suggest --optimize-autoloader'
 
@@ -57,7 +57,7 @@ jobs:
         run: |
           git config --global user.name 'Dennis Claassen'
           git config --global user.email 'd-claassen@users.noreply.github.com'
-          git add package.json style.css
+          git add package.json package-lock.json style.css
           git commit -m 'Release version ${{ github.event.milestone.title }}'
           git tag ${{ github.event.milestone.title }}
           git push --follow-tags
@@ -97,4 +97,4 @@ jobs:
           # description: '"Next Release. The semver size might be altered after creation."'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-       
+


### PR DESCRIPTION
The updated version in the `package-lock.json` file wasn't updated on a release. This fixes that.