### PR TITLE
ADD SVN on Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,9 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=10s --health-retries=10
 
     steps:
+      - name: Install subversion
+        run: sudo apt-get install -y subversion
+
       - name: 'Checkout'
         uses: actions/checkout@v4
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,9 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=10s --health-retries=10
 
     steps:
+      - name: Install subversion
+        run: sudo apt-get install -y subversion
+
       - name: 'Checkout'
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Ubuntu-latest got updated to 24.04, which no longer contains SVN. This additional step in the CI pipeline installs it again.

Based on https://github.com/Yoast/wordpress-seo/pull/21706.